### PR TITLE
fix typecasting for binary angles

### DIFF
--- a/include/z64math.h
+++ b/include/z64math.h
@@ -101,8 +101,8 @@ typedef VecSphGeo VecGeo;
 #define IS_ZERO(f) (fabsf(f) < 0.008f)
 
 // Angle conversion macros
-#define DEG_TO_BINANG(degrees) (s16)((degrees) * (0x8000 / 180.0f))
-#define RAD_TO_BINANG(radians) (s16)((radians) * (0x8000 / M_PI))
+#define DEG_TO_BINANG(degrees) (s16)(s32)(((degrees) * (0x8000 / 180.0f))
+#define RAD_TO_BINANG(radians) (s16)(s32)(((radians) * (0x8000 / M_PI))
 #define RAD_TO_DEG(radians) ((radians) * (180.0f / M_PI))
 #define DEG_TO_RAD(degrees) ((degrees) * (M_PI / 180.0f))
 #define BINANG_TO_DEG(binang) ((f32)(binang) * (180.0f / 0x8000))


### PR DESCRIPTION
Type casting was broken with gcc. This seeems to correct it.